### PR TITLE
Add gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image:
+  file: .gitpod.dockerfile
+tasks:
+  - init: yarn
+    command: mkdir -p /workspace/data && mongod --dbpath /workspace/data

--- a/README.md
+++ b/README.md
@@ -2,10 +2,4 @@
 Leitor de manga feito em react que busca automaticamente os dados do site na internet, se atualizando sozinho, sem necessidade de manutenção.
 Manga Reader in rect that auto search the data in the internet, it auto updates, with no need of maintenance.
 
-# V-0.1 Changelog
-yarn dependecies installed
-services created
-express installed
-apollo-server installed
-graphql installed
-front-end render-app
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/davimury/React-Manga)


### PR DESCRIPTION
this commit adds support for Gitpod.io, a free automated
dev environment that makes contributing and generally working on GitHub
projects much easier. It allows anyone to start a ready-to-code dev
environment for any branch, issue and pull request with a single click.